### PR TITLE
Slightly reduce intensity of storm talon graphics

### DIFF
--- a/Projectiles/Melee/StormTalonProjectile.cs
+++ b/Projectiles/Melee/StormTalonProjectile.cs
@@ -7,6 +7,9 @@ namespace OvermorrowMod.Projectiles.Melee
 {
     public class StormTalonProjectile : ModProjectile
     {
+        // Higher is slower
+        private const int projectileSpawnRate = 1;
+
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Storm Talon");
@@ -73,7 +76,7 @@ namespace OvermorrowMod.Projectiles.Melee
             // Change the spear position projectiled off of the velocity and the movementFactor
             projectile.position += projectile.velocity * movementFactor;
 
-            if (projectile.ai[1] % 1 == 0)
+            if (projectile.ai[1] % projectileSpawnRate == 0)
             {
                 Projectile.NewProjectile(projectile.Center, new Vector2(0, 0), ModContent.ProjectileType<StormTalonSparks>(), (projectile.damage / 4) + 2, 1, projectile.owner, 0, 0);
             }
@@ -90,23 +93,7 @@ namespace OvermorrowMod.Projectiles.Melee
             if (projectile.spriteDirection == -1)
             {
                 projectile.rotation -= MathHelper.ToRadians(90f);
-            }
-
-            // These dusts are added later, for the 'ExampleMod' effect
-            if (Main.rand.NextBool(3))
-            {
-                Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, DustID.UnusedWhiteBluePurple,
-                    projectile.velocity.X * .2f, projectile.velocity.Y * .2f, 200, Scale: 1.2f);
-                dust.velocity += projectile.velocity * 0.3f;
-                dust.velocity *= 0.2f;
-            }
-            if (Main.rand.NextBool(4))
-            {
-                Dust dust = Dust.NewDustDirect(projectile.position, projectile.height, projectile.width, DustID.UnusedWhiteBluePurple,
-                    0, 0, 254, Scale: 0.3f);
-                dust.velocity += projectile.velocity * 0.5f;
-                dust.velocity *= 0.5f;
-            }
+            }            
         }
     }
 }

--- a/Projectiles/Melee/StormTalonSparks.cs
+++ b/Projectiles/Melee/StormTalonSparks.cs
@@ -21,18 +21,17 @@ namespace OvermorrowMod.Projectiles.Melee
             projectile.penetrate = -1;
             projectile.timeLeft = 65;
             projectile.alpha = 255;
-            projectile.tileCollide = true;
+            projectile.tileCollide = false;
             projectile.melee = true;
         }
 
         public override void AI()
         {
             Lighting.AddLight(projectile.Center, 0, 0.5f, 0.5f);
-
-            projectile.localAI[0] += 1f;
-            if (projectile.localAI[0] > 3f)
+            if (projectile.localAI[0]++ >= 2f)
             {
                 Dust.NewDustPerfect(projectile.Center, 206, null, 0, default, 1.5f);
+                projectile.localAI[0] = 0f;
             }
         }
     }


### PR DESCRIPTION
I'm not entirely sure how storm talon would crash the game, unless it just decides to die when spawning too much dust (not impossible).

This PR should reduce the amount of sprites by more than 1/3, and it still looks fine, not exactly as before, but with roughly the same effect. If more intensity is desired without sacrificing performance again we could up the size of the dust to 2 from 1.5, gives more overlap.

