### PR TITLE
Improve trails

### DIFF
--- a/Effects/Prim/PrimitiveHelper.cs
+++ b/Effects/Prim/PrimitiveHelper.cs
@@ -1,7 +1,7 @@
 using Terraria;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using Terraria.ModLoader;
+using System.Collections.Generic;
 
 namespace OvermorrowMod.Effects.Prim
 {
@@ -37,16 +37,16 @@ namespace OvermorrowMod.Effects.Prim
 		{
 			return new Vector3(vec.X, vec.Y, 0);
 		}
-        public static Vector2 GetRotation(Vector2[] oldPos, int index)
+        public static Vector2 GetRotation(IReadOnlyList<Vector2> oldPos, int index)
 		{
-			if (oldPos.Length == 1)
+			if (oldPos.Count == 1)
 				return oldPos[0];
                 
 			if (index == 0) {
 				return Vector2.Normalize(oldPos[1] - oldPos[0]).RotatedBy(MathHelper.Pi / 2);
 			}
 
-			return (index == oldPos.Length - 1
+			return (index == oldPos.Count - 1
 				? Vector2.Normalize(oldPos[index] - oldPos[index - 1])
 				: Vector2.Normalize(oldPos[index + 1] - oldPos[index - 1])).RotatedBy(MathHelper.Pi / 2);
 		}

--- a/Effects/Prim/PrimitiveHelper.cs
+++ b/Effects/Prim/PrimitiveHelper.cs
@@ -34,22 +34,22 @@ namespace OvermorrowMod.Effects.Prim
             return View * Projection;
         }
         public static Vector3 ToVector3(this Vector2 vec)
-		{
-			return new Vector3(vec.X, vec.Y, 0);
-		}
+        {
+            return new Vector3(vec.X, vec.Y, 0);
+        }
         public static Vector2 GetRotation(IReadOnlyList<Vector2> oldPos, int index)
-		{
-			if (oldPos.Count == 1)
-				return oldPos[0];
+        {
+            if (oldPos.Count == 1)
+                return oldPos[0];
                 
-			if (index == 0) {
-				return Vector2.Normalize(oldPos[1] - oldPos[0]).RotatedBy(MathHelper.Pi / 2);
-			}
+            if (index == 0) {
+                return Vector2.Normalize(oldPos[1] - oldPos[0]).RotatedBy(MathHelper.Pi / 2);
+            }
 
-			return (index == oldPos.Count - 1
-				? Vector2.Normalize(oldPos[index] - oldPos[index - 1])
-				: Vector2.Normalize(oldPos[index + 1] - oldPos[index - 1])).RotatedBy(MathHelper.Pi / 2);
-		}
+            return (index == oldPos.Count - 1
+                ? Vector2.Normalize(oldPos[index] - oldPos[index - 1])
+                : Vector2.Normalize(oldPos[index + 1] - oldPos[index - 1])).RotatedBy(MathHelper.Pi / 2);
+        }
         public static void SetBasicEffectParameters(this Effect effect)
         {
             effect.Parameters["WVP"].SetValue(GetMatrix());

--- a/Effects/Prim/Trail.cs
+++ b/Effects/Prim/Trail.cs
@@ -74,9 +74,8 @@ namespace OvermorrowMod.Effects.Prim
         {
             int p = orig(X, Y, SpeedX, SpeedY, type, damage, Knockback, owner, ai0, ai1);
             Projectile projectile = Main.projectile[p];
-            if (projectile.modProjectile != null && projectile.modProjectile is ITrailEntity)
+            if (projectile.modProjectile is ITrailEntity entity)
             {
-                ITrailEntity entity = projectile.modProjectile as ITrailEntity;
                 Trail trail = (Trail)Activator.CreateInstance(entity.TrailType());
                 trail.SetDefaults();
                 trail.DrawType = DrawType.Projectile;
@@ -226,8 +225,7 @@ namespace OvermorrowMod.Effects.Prim
         }
         public Effect Effect = OvermorrowModFile.Mod.TrailShader;
         public List<VertexPositionColorTexture> Vertices = new List<VertexPositionColorTexture>();
-        public List<Vector2> Positions = new List<Vector2>();
-        public int Length = 10;
+        public TrailPositionBuffer Positions;
         public bool Dying = false;
         public bool Dead = false;
         public int EntityID = -1;
@@ -235,6 +233,12 @@ namespace OvermorrowMod.Effects.Prim
         public ITrailEntity TrailEntity;
         public DrawType DrawType = DrawType.Projectile;
         public bool Pixelated = false;
+
+        protected Trail(int length)
+        {
+            Positions = new TrailPositionBuffer(length);
+        }
+
         public void AddVertex(Vector2 pos, Color color, Vector2 texCoord)
         {
             if (!Pixelated)
@@ -247,13 +251,7 @@ namespace OvermorrowMod.Effects.Prim
             }
             Vertices.Add(new VertexPositionColorTexture(new Vector3(pos.X, pos.Y, 0), color, texCoord));
         }
-        public void TrimToLength()
-        {
-            if (Positions.Count > Length)
-            {
-                Positions.RemoveAt(0);
-            }
-        }
+
         public virtual void SetDefaults()
         {
 

--- a/Effects/Prim/Trail.cs
+++ b/Effects/Prim/Trail.cs
@@ -61,7 +61,6 @@ namespace OvermorrowMod.Effects.Prim
             {
                 ITrailEntity entity = npc.modNPC as ITrailEntity;
                 Trail trail = (Trail)Activator.CreateInstance(entity.TrailType());
-                trail.SetDefaults();
                 trail.DrawType = DrawType.NPC;
                 trail.Entity = npc;
                 trail.EntityID = npc.whoAmI;
@@ -77,7 +76,6 @@ namespace OvermorrowMod.Effects.Prim
             if (projectile.modProjectile is ITrailEntity entity)
             {
                 Trail trail = (Trail)Activator.CreateInstance(entity.TrailType());
-                trail.SetDefaults();
                 trail.DrawType = DrawType.Projectile;
                 trail.Entity = projectile;
                 trail.EntityID = projectile.whoAmI;
@@ -165,7 +163,7 @@ namespace OvermorrowMod.Effects.Prim
         }
         public static void DrawProjectileTrails(On.Terraria.Main.orig_DrawProjectiles orig, Main self)
         {
-            foreach(Trail trail in trails)
+            foreach (Trail trail in trails)
             {
                 if (trail.DrawType == DrawType.Projectile && !trail.Pixelated)
                 {
@@ -223,9 +221,10 @@ namespace OvermorrowMod.Effects.Prim
             NPCTarget = null;
             ProjTarget = null;
         }
-        public Effect Effect = OvermorrowModFile.Mod.TrailShader;
-        public List<VertexPositionColorTexture> Vertices = new List<VertexPositionColorTexture>();
-        public TrailPositionBuffer Positions;
+        protected Effect Effect { get; } 
+        protected List<VertexPositionColorTexture> Vertices { get; } = new List<VertexPositionColorTexture>();
+        protected Texture2D Texture { get; }
+        protected TrailPositionBuffer Positions { get; }
         public bool Dying = false;
         public bool Dead = false;
         public int EntityID = -1;
@@ -234,9 +233,11 @@ namespace OvermorrowMod.Effects.Prim
         public DrawType DrawType = DrawType.Projectile;
         public bool Pixelated = false;
 
-        protected Trail(int length)
+        protected Trail(int length, Texture2D texture, Effect effect = null)
         {
             Positions = new TrailPositionBuffer(length);
+            Texture = texture;
+            Effect = effect ?? OvermorrowModFile.Mod.TrailShader;
         }
 
         public void AddVertex(Vector2 pos, Color color, Vector2 texCoord)
@@ -252,25 +253,9 @@ namespace OvermorrowMod.Effects.Prim
             Vertices.Add(new VertexPositionColorTexture(new Vector3(pos.X, pos.Y, 0), color, texCoord));
         }
 
-        public virtual void SetDefaults()
-        {
-
-        }
-        public virtual void Update()
-        {
-
-        }
-        public virtual void PrepareTrail()
-        {
-
-        }
-        public virtual void Draw(SpriteBatch spriteBatch)
-        {
-
-        }
-        public virtual void UpdateDead()
-        {
-
-        }
+        public abstract void Update();
+        public abstract void PrepareTrail();
+        public abstract void Draw(SpriteBatch spriteBatch);
+        public abstract void UpdateDead();
     }
 }

--- a/Effects/Prim/TrailPositionBuffer.cs
+++ b/Effects/Prim/TrailPositionBuffer.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OvermorrowMod.Effects.Prim
+{
+    /// <summary>
+    /// Simple circular buffer for storing trail positions.
+    /// Adapted from https://github.com/joaoportela/CircularBuffer-CSharp
+    /// </summary>
+    public class TrailPositionBuffer : IReadOnlyList<Vector2>
+    {
+        private Vector2[] buffer;
+        private int start;
+        private int size;
+        private int end;
+
+        public TrailPositionBuffer(int capacity)
+        {
+            if (capacity <= 0) throw new ArgumentOutOfRangeException("Capacity must be a positive number");
+            buffer = new Vector2[capacity];
+            start = 0;
+            end = 0;
+            size = 0;
+        }
+
+        public int Capacity { get => buffer.Length; }
+
+        // We only need push-back and pop-front, so we only add those.
+        public void PushBack(Vector2 item)
+        {
+            if (IsFull)
+            {
+                buffer[end] = item;
+                Increment(ref end);
+                start = end;
+            }
+            else
+            {
+                buffer[end] = item;
+                Increment(ref end);
+                ++size;
+            }
+        }
+
+        public void PopFront()
+        {
+            if (IsEmpty) throw new InvalidOperationException("Cannot take elements from an empty buffer.");
+            Increment(ref start);
+            --size;
+        }
+
+        public bool IsFull
+        {
+            get
+            {
+                return Count == Capacity;
+            }
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                return Count == 0;
+            }
+        }
+
+        public int Count => size;
+
+        private void Increment(ref int index)
+        {
+            if (++index == Capacity)
+            {
+                index = 0;
+            }
+        }
+
+        private int InternalIndex(int index)
+        {
+            return start + (index < (Capacity - start) ? index : index - Capacity);
+        }
+
+        public IEnumerator<Vector2> GetEnumerator()
+        {
+            for (int i = start; i < size; i++)
+            {
+                yield return buffer[i % Capacity];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public Vector2 this[int index]
+        {
+            get
+            {
+                if (IsEmpty)
+                {
+                    throw new IndexOutOfRangeException($"Cannot access index {index}. Buffer is empty");
+                }
+                if (index >= size)
+                {
+                    throw new IndexOutOfRangeException($"Cannot access index {index}. Buffer size is {size}");
+                }
+                int actualIndex = InternalIndex(index);
+                return buffer[actualIndex];
+            }
+            set
+            {
+                if (IsEmpty)
+                {
+                    throw new IndexOutOfRangeException($"Cannot access index {index}. Buffer is empty");
+                }
+                if (index >= size)
+                {
+                    throw new IndexOutOfRangeException($"Cannot access index {index}. Buffer size is {size}");
+                }
+                int actualIndex = InternalIndex(index);
+                buffer[actualIndex] = value;
+            }
+        }
+    }
+}

--- a/Effects/Prim/Trails/FireTrail.cs
+++ b/Effects/Prim/Trails/FireTrail.cs
@@ -4,66 +4,10 @@ using Terraria;
 
 namespace OvermorrowMod.Effects.Prim.Trails
 {
-    public class FireTrail : Trail
+    public class FireTrail : SimpleTrail
     {
-        public FireTrail() : base(22)
+        public FireTrail() : base(22, OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail3"), true)
         {
-        }
-
-        private float Offset;
-        public override void SetDefaults()
-        {
-            Effect = OvermorrowModFile.Mod.TrailShader;
-        }
-        public override void Update()
-        {
-            Offset += (1f / Positions.Capacity);
-            Positions.PushBack(Entity.Center);
-        }
-        public override void UpdateDead()
-        {
-            if (Positions.Count < 2)
-            {
-                Dead = true;
-                return;
-            }
-            Positions.PopFront();
-        }
-        public override void PrepareTrail()
-        {
-            if (Positions.Count < 2) return;
-            for (int i = 0; i < Positions.Count - 1; i++)
-            {
-                float prog1 = (float)(i) / (float)Positions.Capacity;
-                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
-                Vector2 pos1 = Positions[i];
-                Vector2 pos2 = Positions[i + 1];
-                
-                if (pos1 == pos2) continue;
-
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
-                Color col1 = Color.Lerp(Color.Red, Color.Orange, prog1) * prog1;
-                Color col2 = Color.Lerp(Color.Red, Color.Orange, prog2) * prog2;
-
-                AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-                AddVertex(pos2 - off2, col2, new Vector2(prog2 + Offset, 0));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-            }
-        }
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            if (Vertices.Count < 6) return;
-            GraphicsDevice device = Main.graphics.GraphicsDevice;
-            RasterizerState rasterizerState = new RasterizerState();
-            rasterizerState.CullMode = CullMode.None;
-            device.RasterizerState = rasterizerState;
-
-            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
         }
     }
 }

--- a/Effects/Prim/Trails/FireTrail.cs
+++ b/Effects/Prim/Trails/FireTrail.cs
@@ -6,17 +6,19 @@ namespace OvermorrowMod.Effects.Prim.Trails
 {
     public class FireTrail : Trail
     {
+        public FireTrail() : base(22)
+        {
+        }
+
         private float Offset;
         public override void SetDefaults()
         {
-            Length = 22;
             Effect = OvermorrowModFile.Mod.TrailShader;
         }
         public override void Update()
         {
-            Offset += (1f / Length);
-            Positions.Add(Entity.Center);
-            if (Positions.Count > Length) Positions.RemoveAt(0);
+            Offset += (1f / Positions.Capacity);
+            Positions.PushBack(Entity.Center);
         }
         public override void UpdateDead()
         {
@@ -25,21 +27,25 @@ namespace OvermorrowMod.Effects.Prim.Trails
                 Dead = true;
                 return;
             }
-            Positions.RemoveAt(0);
+            Positions.PopFront();
         }
         public override void PrepareTrail()
         {
             if (Positions.Count < 2) return;
             for (int i = 0; i < Positions.Count - 1; i++)
             {
-                float prog1 = (float)(i) / (float)Length;
-                float prog2 = (float)(i + 1) / (float)Length;
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
                 Vector2 pos1 = Positions[i];
                 Vector2 pos2 = Positions[i + 1];
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions.ToArray(), i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions.ToArray(), i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+                
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
                 Color col1 = Color.Lerp(Color.Red, Color.Orange, prog1) * prog1;
                 Color col2 = Color.Lerp(Color.Red, Color.Orange, prog2) * prog2;
+
                 AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
                 AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
                 AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));

--- a/Effects/Prim/Trails/LightningTrail.cs
+++ b/Effects/Prim/Trails/LightningTrail.cs
@@ -4,71 +4,10 @@ using Terraria;
 
 namespace OvermorrowMod.Effects.Prim.Trails
 {
-    public class LightningTrail : Trail
+    public class LightningTrail : SimpleTrail
     {
-        public LightningTrail() : base(40)
+        public LightningTrail() : base(40, OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail5"), true)
         {
-        }
-
-        public override void SetDefaults()
-        {
-            Effect = OvermorrowModFile.Mod.TrailShader;
-        }
-        float Offset;
-        public override void Update()
-        {
-            Offset += (1f / Positions.Capacity);
-            Positions.PushBack(Entity.Center);
-        }
-        public override void UpdateDead()
-        {
-            if (Positions.Count < 2)
-            {
-                Dead = true;
-                return;
-            }
-            Positions.PopFront();
-        }
-       
-        public override void PrepareTrail()
-        {
-            if (Positions.Count < 2) return;
-            for (int i = 0; i < Positions.Count - 1; i++)
-            {
-                float prog1 = (float)(i) / (float)Positions.Capacity;
-                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
-                Vector2 pos1 = Positions[i];
-                Vector2 pos2 = Positions[i + 1];
-
-                if (pos1 == pos2) continue;
-
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
-                Color col1 = TrailEntity.TrailColor(prog1);
-                Color col2 = TrailEntity.TrailColor(prog2);
-
-                AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-                AddVertex(pos2 - off2, col2, new Vector2(prog2 + Offset, 0));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-            }
-        }
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            Effect.SafeSetParameter("WorldViewProjection", PrimitiveHelper.GetMatrix());
-            Effect.SafeSetParameter("uImage0", OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail5"));
-            Effect.CurrentTechnique.Passes["Texturized"].Apply();
-
-            if (Vertices.Count < 6) return;
-            GraphicsDevice device = Main.graphics.GraphicsDevice;
-            RasterizerState rasterizerState = new RasterizerState();
-            rasterizerState.CullMode = CullMode.None;
-            device.RasterizerState = rasterizerState;
-
-            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
         }
     }
 }

--- a/Effects/Prim/Trails/LightningTrail.cs
+++ b/Effects/Prim/Trails/LightningTrail.cs
@@ -6,17 +6,19 @@ namespace OvermorrowMod.Effects.Prim.Trails
 {
     public class LightningTrail : Trail
     {
+        public LightningTrail() : base(40)
+        {
+        }
+
         public override void SetDefaults()
         {
-            Length = 40;
             Effect = OvermorrowModFile.Mod.TrailShader;
         }
         float Offset;
         public override void Update()
         {
-            Offset += (1f / Length);
-            Positions.Add(Entity.Center);
-            if (Positions.Count > Length) Positions.RemoveAt(0);
+            Offset += (1f / Positions.Capacity);
+            Positions.PushBack(Entity.Center);
         }
         public override void UpdateDead()
         {
@@ -25,7 +27,7 @@ namespace OvermorrowMod.Effects.Prim.Trails
                 Dead = true;
                 return;
             }
-            Positions.RemoveAt(0);
+            Positions.PopFront();
         }
        
         public override void PrepareTrail()
@@ -33,14 +35,18 @@ namespace OvermorrowMod.Effects.Prim.Trails
             if (Positions.Count < 2) return;
             for (int i = 0; i < Positions.Count - 1; i++)
             {
-                float prog1 = (float)(i) / (float)Length;
-                float prog2 = (float)(i + 1) / (float)Length;
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
                 Vector2 pos1 = Positions[i];
                 Vector2 pos2 = Positions[i + 1];
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions.ToArray(), i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions.ToArray(), i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
                 Color col1 = TrailEntity.TrailColor(prog1);
                 Color col2 = TrailEntity.TrailColor(prog2);
+
                 AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
                 AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
                 AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));

--- a/Effects/Prim/Trails/SimpleTrail.cs
+++ b/Effects/Prim/Trails/SimpleTrail.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+
+namespace OvermorrowMod.Effects.Prim.Trails
+{
+    public class SimpleTrail : Trail
+    {
+        protected float offset;
+        private bool useOffset;
+        public SimpleTrail(int length, Texture2D texture, bool useOffset = false, Effect effect = null)
+            : base(length, texture, effect)
+        {
+            this.useOffset = useOffset;
+        }
+
+        public override void Draw(SpriteBatch spriteBatch)
+        {
+            if (Vertices.Count < 6) return;
+
+            Effect.SafeSetParameter("WorldViewProjection", PrimitiveHelper.GetMatrix());
+            Effect.SafeSetParameter("uImage0", Texture);
+            Effect.CurrentTechnique.Passes["Texturized"].Apply();
+
+            GraphicsDevice device = Main.graphics.GraphicsDevice;
+            RasterizerState rasterizerState = new RasterizerState();
+            rasterizerState.CullMode = CullMode.None;
+            device.RasterizerState = rasterizerState;
+
+            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
+        }
+
+        public override void PrepareTrail()
+        {
+            if (Positions.Count < 2) return;
+            for (int i = 0; i < Positions.Count - 1; i++)
+            {
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
+                Vector2 pos1 = Positions[i];
+                Vector2 pos2 = Positions[i + 1];
+
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+                Color col1 = TrailEntity.TrailColor(prog1);
+                Color col2 = TrailEntity.TrailColor(prog2);
+
+                AddVertex(pos1 + off1, col1, new Vector2(prog1 + offset, 1));
+                AddVertex(pos1 - off1, col1, new Vector2(prog1 + offset, 0));
+                AddVertex(pos2 + off2, col2, new Vector2(prog2 + offset, 1));
+
+                AddVertex(pos2 + off2, col2, new Vector2(prog2 + offset, 1));
+                AddVertex(pos2 - off2, col2, new Vector2(prog2 + offset, 0));
+                AddVertex(pos1 - off1, col1, new Vector2(prog1 + offset, 0));
+            }
+        }
+
+        public override void Update()
+        {
+            if (useOffset) offset += (1f / Positions.Capacity);
+            Positions.PushBack(Entity.Center);
+        }
+
+        public override void UpdateDead()
+        {
+            if (Positions.Count < 2)
+            {
+                Dead = true;
+                return;
+            }
+            Positions.PopFront();
+        }
+    }
+}

--- a/Effects/Prim/Trails/SixShooterTrail.cs
+++ b/Effects/Prim/Trails/SixShooterTrail.cs
@@ -4,70 +4,10 @@ using Terraria;
 
 namespace OvermorrowMod.Effects.Prim.Trails
 {
-    public class SixShooterTrail : Trail
+    public class SixShooterTrail : SimpleTrail
     {
-        public SixShooterTrail() : base(20)
+        public SixShooterTrail() : base(20, OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail6"), true)
         {
-        }
-
-        private float Offset;
-        public override void SetDefaults()
-        {
-            Effect = OvermorrowModFile.Mod.TrailShader;
-        }
-        public override void Update()
-        {
-            Offset += (1f / Positions.Capacity);
-            Positions.PushBack(Entity.Center);
-        }
-        public override void UpdateDead()
-        {
-            if (Positions.Count < 2)
-            {
-                Dead = true;
-                return;
-            }
-            Positions.PopFront();
-        }
-       
-        public override void PrepareTrail()
-        {
-            Color darkest = new Color(6, 106, 255);
-            Color lightest = new Color(196, 247, 258);
-
-            if (Positions.Count < 2) return;
-            for (int i = 0; i < Positions.Count - 1; i++)
-            {
-                float prog1 = (float)(i) / (float)Positions.Capacity;
-                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
-                Vector2 pos1 = Positions[i];
-                Vector2 pos2 = Positions[i + 1];
-
-                if (pos1 == pos2) continue;
-
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
-                Color col1 = Color.Lerp(darkest, lightest, prog1) * prog1;
-                Color col2 = Color.Lerp(darkest, lightest, prog2) * prog2;
-
-                AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-                AddVertex(pos2 - off2, col2, new Vector2(prog2 + Offset, 0));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-            }
-        }
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            if (Vertices.Count < 6) return;
-            GraphicsDevice device = Main.graphics.GraphicsDevice;
-            RasterizerState rasterizerState = new RasterizerState();
-            rasterizerState.CullMode = CullMode.None;
-            device.RasterizerState = rasterizerState;
-
-            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
         }
     }
 }

--- a/Effects/Prim/Trails/SixShooterTrail.cs
+++ b/Effects/Prim/Trails/SixShooterTrail.cs
@@ -6,17 +6,19 @@ namespace OvermorrowMod.Effects.Prim.Trails
 {
     public class SixShooterTrail : Trail
     {
+        public SixShooterTrail() : base(20)
+        {
+        }
+
         private float Offset;
         public override void SetDefaults()
         {
-            Length = 20;
             Effect = OvermorrowModFile.Mod.TrailShader;
         }
         public override void Update()
         {
-            Offset += (1f / Length);
-            Positions.Add(Entity.Center);
-            if (Positions.Count > Length) Positions.RemoveAt(0);
+            Offset += (1f / Positions.Capacity);
+            Positions.PushBack(Entity.Center);
         }
         public override void UpdateDead()
         {
@@ -25,7 +27,7 @@ namespace OvermorrowMod.Effects.Prim.Trails
                 Dead = true;
                 return;
             }
-            Positions.RemoveAt(0);
+            Positions.PopFront();
         }
        
         public override void PrepareTrail()
@@ -36,14 +38,18 @@ namespace OvermorrowMod.Effects.Prim.Trails
             if (Positions.Count < 2) return;
             for (int i = 0; i < Positions.Count - 1; i++)
             {
-                float prog1 = (float)(i) / (float)Length;
-                float prog2 = (float)(i + 1) / (float)Length;
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
                 Vector2 pos1 = Positions[i];
                 Vector2 pos2 = Positions[i + 1];
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions.ToArray(), i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions.ToArray(), i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
                 Color col1 = Color.Lerp(darkest, lightest, prog1) * prog1;
                 Color col2 = Color.Lerp(darkest, lightest, prog2) * prog2;
+
                 AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
                 AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
                 AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));

--- a/Effects/Prim/Trails/SkullTrail.cs
+++ b/Effects/Prim/Trails/SkullTrail.cs
@@ -6,17 +6,20 @@ namespace OvermorrowMod.Effects.Prim.Trails
 {
     public class SkullTrail : Trail
     {
+        public SkullTrail() : base(12)
+        {
+        }
+
+
         private float Offset;
         public override void SetDefaults()
         {
-            Length = 12;
             Effect = OvermorrowModFile.Mod.TrailShader;
         }
         public override void Update()
         {
-            Offset += (1f / Length);
-            Positions.Add(Entity.Center);
-            if (Positions.Count > Length) Positions.RemoveAt(0);
+            Offset += (1f / Positions.Capacity);
+            Positions.PushBack(Entity.Center);
         }
         public override void UpdateDead()
         {
@@ -25,7 +28,7 @@ namespace OvermorrowMod.Effects.Prim.Trails
                 Dead = true;
                 return;
             }
-            Positions.RemoveAt(0);
+            Positions.PopFront();
         }
        
         public override void PrepareTrail()
@@ -33,14 +36,18 @@ namespace OvermorrowMod.Effects.Prim.Trails
             if (Positions.Count < 2) return;
             for (int i = 0; i < Positions.Count - 1; i++)
             {
-                float prog1 = (float)(i) / (float)Length;
-                float prog2 = (float)(i + 1) / (float)Length;
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
                 Vector2 pos1 = Positions[i];
                 Vector2 pos2 = Positions[i + 1];
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions.ToArray(), i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions.ToArray(), i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
                 Color col1 = Color.Lerp(Color.Cyan, Color.LightCyan, prog1) * prog1;
                 Color col2 = Color.Lerp(Color.Cyan, Color.LightCyan, prog2) * prog2;
+
                 AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
                 AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
                 AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));

--- a/Effects/Prim/Trails/SkullTrail.cs
+++ b/Effects/Prim/Trails/SkullTrail.cs
@@ -4,68 +4,10 @@ using Terraria;
 
 namespace OvermorrowMod.Effects.Prim.Trails
 {
-    public class SkullTrail : Trail
+    public class SkullTrail : SimpleTrail
     {
-        public SkullTrail() : base(12)
+        public SkullTrail() : base(12, OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail6"), true)
         {
-        }
-
-
-        private float Offset;
-        public override void SetDefaults()
-        {
-            Effect = OvermorrowModFile.Mod.TrailShader;
-        }
-        public override void Update()
-        {
-            Offset += (1f / Positions.Capacity);
-            Positions.PushBack(Entity.Center);
-        }
-        public override void UpdateDead()
-        {
-            if (Positions.Count < 2)
-            {
-                Dead = true;
-                return;
-            }
-            Positions.PopFront();
-        }
-       
-        public override void PrepareTrail()
-        {
-            if (Positions.Count < 2) return;
-            for (int i = 0; i < Positions.Count - 1; i++)
-            {
-                float prog1 = (float)(i) / (float)Positions.Capacity;
-                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
-                Vector2 pos1 = Positions[i];
-                Vector2 pos2 = Positions[i + 1];
-
-                if (pos1 == pos2) continue;
-
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
-                Color col1 = Color.Lerp(Color.Cyan, Color.LightCyan, prog1) * prog1;
-                Color col2 = Color.Lerp(Color.Cyan, Color.LightCyan, prog2) * prog2;
-
-                AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-                AddVertex(pos2 - off2, col2, new Vector2(prog2 + Offset, 0));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-            }
-        }
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            if (Vertices.Count < 6) return;
-            GraphicsDevice device = Main.graphics.GraphicsDevice;
-            RasterizerState rasterizerState = new RasterizerState();
-            rasterizerState.CullMode = CullMode.None;
-            device.RasterizerState = rasterizerState;
-
-            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
         }
     }
 }

--- a/Effects/Prim/Trails/SoulTrail.cs
+++ b/Effects/Prim/Trails/SoulTrail.cs
@@ -4,65 +4,10 @@ using Terraria;
 
 namespace OvermorrowMod.Effects.Prim.Trails
 {
-    public class SoulTrail : Trail
+    public class SoulTrail : SimpleTrail
     {
-        public SoulTrail() : base(30)
+        public SoulTrail() : base(30, OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail1"))
         {
-        }
-
-        public override void SetDefaults()
-        {
-            Effect = OvermorrowModFile.Mod.TrailShader;
-        }
-        public override void Update()
-        {
-            Positions.PushBack(Entity.Center);
-        }
-        public override void UpdateDead()
-        {
-            if (Positions.Count < 2)
-            {
-                Dead = true;
-                return;
-            }
-            Positions.PopFront();
-        }
-       
-        public override void PrepareTrail()
-        {
-            if (Positions.Count < 2) return;
-            for (int i = 0; i < Positions.Count - 1; i++)
-            {
-                float prog1 = (float)(i) / (float)Positions.Capacity;
-                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
-                Vector2 pos1 = Positions[i];
-                Vector2 pos2 = Positions[i + 1];
-
-                if (pos1 == pos2) continue;
-
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
-                Color col1 = Color.Lerp(new Color(74, 43, 100), new Color(120, 141, 239), prog1) * prog1;
-                Color col2 = Color.Lerp(new Color(74, 43, 100), new Color(120, 141, 239), prog2) * prog2;
-                                
-                AddVertex(pos1 + off1, col1, new Vector2(prog1, 1));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1, 0));
-                AddVertex(pos2 + off2, col2, new Vector2(prog2, 1));
-
-                AddVertex(pos2 + off2, col2, new Vector2(prog2, 1));
-                AddVertex(pos2 - off2, col2, new Vector2(prog2, 0));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1, 0));
-            }
-        }
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            if (Vertices.Count < 6) return;
-            GraphicsDevice device = Main.graphics.GraphicsDevice;
-            RasterizerState rasterizerState = new RasterizerState();
-            rasterizerState.CullMode = CullMode.None;
-            device.RasterizerState = rasterizerState;
-
-            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
         }
     }
 }

--- a/Effects/Prim/Trails/SoulTrail.cs
+++ b/Effects/Prim/Trails/SoulTrail.cs
@@ -6,15 +6,17 @@ namespace OvermorrowMod.Effects.Prim.Trails
 {
     public class SoulTrail : Trail
     {
+        public SoulTrail() : base(30)
+        {
+        }
+
         public override void SetDefaults()
         {
-            Length = 30;
             Effect = OvermorrowModFile.Mod.TrailShader;
         }
         public override void Update()
         {
-            Positions.Add(Entity.Center);
-            if (Positions.Count > Length) Positions.RemoveAt(0);
+            Positions.PushBack(Entity.Center);
         }
         public override void UpdateDead()
         {
@@ -23,7 +25,7 @@ namespace OvermorrowMod.Effects.Prim.Trails
                 Dead = true;
                 return;
             }
-            Positions.RemoveAt(0);
+            Positions.PopFront();
         }
        
         public override void PrepareTrail()
@@ -31,14 +33,18 @@ namespace OvermorrowMod.Effects.Prim.Trails
             if (Positions.Count < 2) return;
             for (int i = 0; i < Positions.Count - 1; i++)
             {
-                float prog1 = (float)(i) / (float)Length;
-                float prog2 = (float)(i + 1) / (float)Length;
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
                 Vector2 pos1 = Positions[i];
                 Vector2 pos2 = Positions[i + 1];
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions.ToArray(), i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions.ToArray(), i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
                 Color col1 = Color.Lerp(new Color(74, 43, 100), new Color(120, 141, 239), prog1) * prog1;
                 Color col2 = Color.Lerp(new Color(74, 43, 100), new Color(120, 141, 239), prog2) * prog2;
+                                
                 AddVertex(pos1 + off1, col1, new Vector2(prog1, 1));
                 AddVertex(pos1 - off1, col1, new Vector2(prog1, 0));
                 AddVertex(pos2 + off2, col2, new Vector2(prog2, 1));

--- a/Effects/Prim/Trails/TorchTrail.cs
+++ b/Effects/Prim/Trails/TorchTrail.cs
@@ -4,67 +4,10 @@ using Terraria;
 
 namespace OvermorrowMod.Effects.Prim.Trails
 {
-    public class TorchTrail : Trail
+    public class TorchTrail : SimpleTrail
     {
-        private float Offset;
-        public TorchTrail() : base(22)
+        public TorchTrail() : base(22, OvermorrowModFile.Mod.GetTexture("Effects/TrailTextures/Trail3"), true)
         {
-        }
-
-        public override void SetDefaults()
-        {
-            Effect = OvermorrowModFile.Mod.TrailShader;
-        }
-        public override void Update()
-        {
-            Offset += (1f / Positions.Capacity);
-            Positions.PushBack(Entity.Center);
-        }
-        public override void UpdateDead()
-        {
-            if (Positions.Count < 2)
-            {
-                Dead = true;
-                return;
-            }
-            Positions.PopFront();
-        }
-       
-        public override void PrepareTrail()
-        {
-            if (Positions.Count < 2) return;
-            for (int i = 0; i < Positions.Count - 1; i++)
-            {
-                float prog1 = (float)(i) / (float)Positions.Capacity;
-                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
-                Vector2 pos1 = Positions[i];
-                Vector2 pos2 = Positions[i + 1];
-
-                if (pos1 == pos2) continue;
-
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
-                Color col1 = Color.Lerp(Main.DiscoColor, Main.DiscoColor, prog1) * prog1;
-                Color col2 = Color.Lerp(Main.DiscoColor, Main.DiscoColor, prog2) * prog2;
-
-                AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-
-                AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));
-                AddVertex(pos2 - off2, col2, new Vector2(prog2 + Offset, 0));
-                AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
-            }
-        }
-        public override void Draw(SpriteBatch spriteBatch)
-        {
-            if (Vertices.Count < 6) return;
-            GraphicsDevice device = Main.graphics.GraphicsDevice;
-            RasterizerState rasterizerState = new RasterizerState();
-            rasterizerState.CullMode = CullMode.None;
-            device.RasterizerState = rasterizerState;
-
-            device.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices.ToArray(), 0, Vertices.Count / 3);
         }
     }
 }

--- a/Effects/Prim/Trails/TorchTrail.cs
+++ b/Effects/Prim/Trails/TorchTrail.cs
@@ -7,16 +7,18 @@ namespace OvermorrowMod.Effects.Prim.Trails
     public class TorchTrail : Trail
     {
         private float Offset;
+        public TorchTrail() : base(22)
+        {
+        }
+
         public override void SetDefaults()
         {
-            Length = 22;
             Effect = OvermorrowModFile.Mod.TrailShader;
         }
         public override void Update()
         {
-            Offset += (1f / Length);
-            Positions.Add(Entity.Center);
-            if (Positions.Count > Length) Positions.RemoveAt(0);
+            Offset += (1f / Positions.Capacity);
+            Positions.PushBack(Entity.Center);
         }
         public override void UpdateDead()
         {
@@ -25,7 +27,7 @@ namespace OvermorrowMod.Effects.Prim.Trails
                 Dead = true;
                 return;
             }
-            Positions.RemoveAt(0);
+            Positions.PopFront();
         }
        
         public override void PrepareTrail()
@@ -33,14 +35,18 @@ namespace OvermorrowMod.Effects.Prim.Trails
             if (Positions.Count < 2) return;
             for (int i = 0; i < Positions.Count - 1; i++)
             {
-                float prog1 = (float)(i) / (float)Length;
-                float prog2 = (float)(i + 1) / (float)Length;
+                float prog1 = (float)(i) / (float)Positions.Capacity;
+                float prog2 = (float)(i + 1) / (float)Positions.Capacity;
                 Vector2 pos1 = Positions[i];
                 Vector2 pos2 = Positions[i + 1];
-                Vector2 off1 = PrimitiveHelper.GetRotation(Positions.ToArray(), i) * TrailEntity.TrailSize(prog1) * prog1;
-                Vector2 off2 = PrimitiveHelper.GetRotation(Positions.ToArray(), i + 1) * TrailEntity.TrailSize(prog2) * prog2;
+
+                if (pos1 == pos2) continue;
+
+                Vector2 off1 = PrimitiveHelper.GetRotation(Positions, i) * TrailEntity.TrailSize(prog1) * prog1;
+                Vector2 off2 = PrimitiveHelper.GetRotation(Positions, i + 1) * TrailEntity.TrailSize(prog2) * prog2;
                 Color col1 = Color.Lerp(Main.DiscoColor, Main.DiscoColor, prog1) * prog1;
                 Color col2 = Color.Lerp(Main.DiscoColor, Main.DiscoColor, prog2) * prog2;
+
                 AddVertex(pos1 + off1, col1, new Vector2(prog1 + Offset, 1));
                 AddVertex(pos1 - off1, col1, new Vector2(prog1 + Offset, 0));
                 AddVertex(pos2 + off2, col2, new Vector2(prog2 + Offset, 1));


### PR DESCRIPTION
Several improvements to trails. This fixes #27, it occurred when the buffer was full of identical positions, some arithmetic nonsense, we can solve it easily enough by just not drawing zero-size vertices, which is probably an optimization anyway.

I also noticed that the trails were just all duplicated code, so I unified them into a single "SimpleTrail" class, use the old Trail class instead if you need to do something different.

The refactor a month ago also dropped the textures for most of the trails, so I added those back.

As for `Positions`:

```
Positions.Add(...)
if (Positions.Count > 30) Positions.RemoveAt(0);
```

Positions has to be copied every single time you do this (it is an array under the hood), so it is wildly inefficient. Same with calling `ToArray()` when you don't need to. What this actually needs is a rotating buffer, so this PR also adds that. Simpler interface, and less unnecessary memory movement, performance is pretty important with trails, so we need to be careful.

I tested the trails, they look alright, at least the same as before. An important difference is that we now get the color from ITrailEntity.TrailColor, so these need to be implemented properly for each trail.