### PR TITLE
Remove doubled trail logic

### DIFF
--- a/Effects/Prim/Trails/SimpleTrail.cs
+++ b/Effects/Prim/Trails/SimpleTrail.cs
@@ -19,7 +19,7 @@ namespace OvermorrowMod.Effects.Prim.Trails
             this.useOffset = useOffset;
         }
 
-        public override void Draw(SpriteBatch spriteBatch)
+        public override void Draw()
         {
             if (Vertices.Count < 6) return;
 


### PR DESCRIPTION
Draw is called twice for some reason. There really is no good reason to do it this way, it is super complicated and unnecessary, from what I can tell. This looks more or less the same (it might be a little thinner, because we no longer _draw the same shit twice_, but I think that should be solved in a different way)

We weren't using the spriteBatch logic in there, so I removed it entirely.

This _will_ fix #34, since the code that caused it no longer exists, but I cannot guarantee that there won't be some other issue on 64 bit TML.