### PR TITLE
Fix blur overlay drawing

### DIFF
--- a/Common/ModDetours.cs
+++ b/Common/ModDetours.cs
@@ -47,7 +47,7 @@ namespace OvermorrowMod.Common
             device.RasterizerState = rasterizerState;
             device.Textures[0] = texture;
 
-            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, data, 0, 4);
+            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, data, 0, 2);
 
             orig(self);
         }


### PR DESCRIPTION
Just a little oopsie, a rectangle has two primitives, not four.