### PR TITLE
Make it impossible for PlayerUUID to be null

### DIFF
--- a/Quests/QuestPlayer.cs
+++ b/Quests/QuestPlayer.cs
@@ -16,7 +16,8 @@ namespace OvermorrowMod.Quests
 {
     public class QuestPlayer : ModPlayer
     {
-        public string PlayerUUID { get; private set; } = null;
+        public string PlayerUUID { get; private set; } = Guid.NewGuid().ToString();
+
         public string SelectedLocation { get; set; } = null;
 
         public IEnumerable<BaseQuestState> CurrentQuests => Quests.State.GetActiveQuests(this);


### PR DESCRIPTION
I'm still not entirely sure why this happens, but I know it can occur when creating a new character.

This should solve the problem, and hopefully not create any new ones...